### PR TITLE
Optimize dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 // Load dependencies.
 const fs = require('fs');
-const unzip = require('unzip');
+const unzip = require('unzip-stream');
 const stripBOM = require('strip-bom');
 const Dictionary = require('./dictionary.js');
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,8 @@
   "dependencies": {
     "binarysearch": "^0.2.4",
     "damerau-levenshtein": "git://github.com/cbaatz/damerau-levenshtein.git",
-    "npm": "^3.8.0",
     "strip-bom": "^2.0.0",
-    "unzip": "^0.1.11"
+    "unzip-stream": "^0.1.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This PR takes two things.

- Remove npm to reduce lot of dependencies.
- Use unzip-stream instead of unzip to get compatibility for webpack.
  Older graceful-fs was used and it causes an error when the code is bundled with webpack.